### PR TITLE
added schema/data server decoupling

### DIFF
--- a/pkg/reconcilers/ctrlconfig/config.go
+++ b/pkg/reconcilers/ctrlconfig/config.go
@@ -17,14 +17,15 @@ limitations under the License.
 package ctrlconfig
 
 import (
-	"github.com/iptecharch/config-server/pkg/reconcilers/context/dsctx"
+	sdcctx "github.com/iptecharch/config-server/pkg/sdc/ctx"
 	"github.com/iptecharch/config-server/pkg/store"
 	"github.com/iptecharch/config-server/pkg/target"
 )
 
 type ControllerConfig struct {
 	//ConfigStore     store.Storer[runtime.Object]
-	TargetStore     store.Storer[target.Context]
-	DataServerStore store.Storer[dsctx.Context]
-	SchemaDir       string
+	TargetStore       store.Storer[target.Context]
+	DataServerStore   store.Storer[sdcctx.DSContext]
+	SchemaServerStore store.Storer[sdcctx.SSContext]
+	SchemaDir         string
 }

--- a/pkg/reconcilers/schema/reconciler.go
+++ b/pkg/reconcilers/schema/reconciler.go
@@ -15,7 +15,7 @@ import (
 
 	invv1alpha1 "github.com/iptecharch/config-server/apis/inv/v1alpha1"
 	"github.com/iptecharch/config-server/pkg/reconcilers"
-	"github.com/iptecharch/config-server/pkg/reconcilers/context/dsctx"
+	sdcctx "github.com/iptecharch/config-server/pkg/sdc/ctx"
 	"github.com/iptecharch/config-server/pkg/reconcilers/ctrlconfig"
 	"github.com/iptecharch/config-server/pkg/reconcilers/resource"
 	schemaloader "github.com/iptecharch/config-server/pkg/schema"
@@ -55,7 +55,7 @@ func (r *reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, c i
 		return nil, err
 	}
 
-	cfg.DataServerStore.List(ctx, func(ctx context.Context, key store.Key, dsCtx dsctx.Context) {
+	cfg.SchemaServerStore.List(ctx, func(ctx context.Context, key store.Key, dsCtx sdcctx.SSContext) {
 		r.schemaclient = dsCtx.SSClient
 	})
 	if r.schemaclient == nil {

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -21,7 +21,7 @@ import (
 
 	invv1alpha1 "github.com/iptecharch/config-server/apis/inv/v1alpha1"
 	"github.com/iptecharch/config-server/pkg/reconcilers"
-	"github.com/iptecharch/config-server/pkg/reconcilers/context/dsctx"
+	sdcctx "github.com/iptecharch/config-server/pkg/sdc/ctx"
 	"github.com/iptecharch/config-server/pkg/reconcilers/ctrlconfig"
 	"github.com/iptecharch/config-server/pkg/reconcilers/resource"
 	dsclient "github.com/iptecharch/config-server/pkg/sdc/dataserver/client"
@@ -79,7 +79,7 @@ type reconciler struct {
 
 	//configStore     store.Storer[runtime.Object]
 	targetStore     store.Storer[target.Context]
-	dataServerStore store.Storer[dsctx.Context]
+	dataServerStore store.Storer[sdcctx.DSContext]
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -235,12 +235,12 @@ func (r *reconciler) addTargetToDataServer(ctx context.Context, dsKey store.Key,
 
 // selectDataServerContext selects a dataserver for a particalur target based on
 // least amount of targets assigned to a dataserver
-func (r *reconciler) selectDataServerContext(ctx context.Context) (*dsctx.Context, error) {
+func (r *reconciler) selectDataServerContext(ctx context.Context) (*sdcctx.DSContext, error) {
 	log := log.FromContext(ctx)
 	var err error
-	selectedDSctx := &dsctx.Context{}
+	selectedDSctx := &sdcctx.DSContext{}
 	minTargets := 9999
-	r.dataServerStore.List(ctx, func(ctx context.Context, k store.Key, dsctx dsctx.Context) {
+	r.dataServerStore.List(ctx, func(ctx context.Context, k store.Key, dsctx sdcctx.DSContext) {
 		if dsctx.Targets.Len() == 0 || dsctx.Targets.Len() < minTargets {
 			selectedDSctx = &dsctx
 			minTargets = dsctx.Targets.Len()

--- a/pkg/sdc/ctx/context.go
+++ b/pkg/sdc/ctx/context.go
@@ -1,4 +1,4 @@
-package dsctx
+package sdcctx
 
 import (
 	dsclient "github.com/iptecharch/config-server/pkg/sdc/dataserver/client"
@@ -6,9 +6,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type Context struct {
+type SSContext struct {
+	Config   *ssclient.Config
+	SSClient ssclient.Client // schemaserver client
+}
+
+type DSContext struct {
 	Config   *dsclient.Config
 	Targets  sets.Set[string]
 	DSClient dsclient.Client // dataserver client
-	SSClient ssclient.Client // schemaserver client
 }


### PR DESCRIPTION
2 env variables are added  
        - name: SDC_DATA_SERVER
          value: "localhost:56000"
        - name: SDC_SCHEMA_SERVER
          value: "localhost:56000"

1. if none is set i assume the default -> localhost:56000 for data/schema-server
2. if SDC_DATA_SERVER is set only -> it will be used for both data and schemaserver
3. if SDC_DATA_SERVER and SDC_SCHEMA_SERVER are set each value is taken for rest. data/schema server
4. if only the SDC_SCHEMA_SERVER is set the dataserver is using localhost:56000