### PR TITLE
updated target reconciler to lineup with data-server v0.0.22

### DIFF
--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -486,18 +486,11 @@ func (r *reconciler) getCreateDataStoreRequest(ctx context.Context, cr *invv1alp
 
 	name, vendor := invv1alpha1.GetVendorType(cr.Status.DiscoveryInfo.Provider)
 
-	protocol := string(connProfile.Spec.Protocol)
-	address := cr.Spec.Address
-	if protocol == "netconf" {
-		protocol = "nc"
-		address = strings.Split(address, ":")[0]
-	}
-
 	return &sdcpb.CreateDataStoreRequest{
 		Name: store.GetNSNKey(types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name}).String(),
 		Target: &sdcpb.Target{
-			Type:    protocol,
-			Address: address,
+			Type:    string(connProfile.Spec.Protocol),
+			Address: cr.Spec.Address,
 			Credentials: &sdcpb.Credentials{
 				Username: string(secret.Data["username"]),
 				Password: string(secret.Data["password"]),


### PR DESCRIPTION
netconf name is now netconf iso nc in the data-server
port/address is conveyed in the address:port iso different approaches for netconf and gnome